### PR TITLE
Temp Frame Modifications

### DIFF
--- a/src/lib/generator/html/frame.ts
+++ b/src/lib/generator/html/frame.ts
@@ -25,11 +25,16 @@ export default ({ node, filename, widthRange, altText, config, variables }) => {
 
 	frameContent.css += `\t${css.frame(id)}`;
 
-	// find all frame nodes within the frame
-	const allNodes = node.findAll((node) => node.type === 'FRAME');
+	// console.log(node);
 
-	// convert all frames to groups for positioning
-	const groups: GroupNode[] = createGroupsFromFrames(allNodes);
+	// // find all frame nodes within the frame
+	// const allNodes = node.findAll((node) => node.type === 'FRAME');
+
+	// // find all frame nodes within the frame with a child node of type TEXT
+	// const allTextNodes = allNodes.filter((node) => node.children.find((child) => child.type === 'TEXT'));
+
+	// // convert all frames to groups for positioning
+	// const groups: GroupNode[] = createGroupsFromFrames(allTextNodes);
 
 	// find all text nodes within the frame
 	const textFrames = node.findAll((child) => child.type === 'TEXT');

--- a/src/lib/generator/html/wrapper.ts
+++ b/src/lib/generator/html/wrapper.ts
@@ -25,6 +25,7 @@ export default ({ config, assets, variables }) => {
 		)
 		.join('\n\n');
 
+
 	html += `\n\n<style>\n${css.page({
 		containerId,
 		config,


### PR DESCRIPTION
Move frame modifications (converting frames containing text node children to groups for positioning) to a temporary frame, as opposed to making adjustment to actual frames.

Also limits modifications to frames with text node children to allow frames to be part of exported image.