### PR TITLE
Adds dynamic and fixed responsive options

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,7 +22,7 @@
   import { onMount } from "svelte";
   import { slide, fade } from "svelte/transition";
   import JSZip from "../node_modules/jszip/dist/jszip.min.js";
-  import { Asset, Config, Extension, FileType, HTMLFile, Scale, Size } from "./types";
+  import { Asset, Config, Extension, FileType, HTMLFile, Scale, Responsiveness, Size } from "./types";
 
   let loading = false,
     menuOpen = false;
@@ -85,6 +85,24 @@
     });
   }
 
+  interface ResponsivenessOption {
+    value: Responsiveness;
+    label: string;
+    selected: boolean;
+  }
+
+  let responsiveness: Responsiveness | undefined = undefined;
+  let responsivenessOptions: ResponsivenessOption[] = [
+    { value: "DYNAMIC", label: "DYNAMIC", selected: false },
+    { value: "FIXED", label: "FIXED", selected: false },
+  ];
+
+  $: {
+    responsivenessOptions.forEach((o, i) => {
+      responsivenessOptions[i].selected = o.value === responsiveness;
+    });
+  }
+
   let syntax: string | undefined = undefined;
   let includeResizer = true;
   let centerHtmlOutput = false;
@@ -119,6 +137,7 @@
       fileType,
       includeResizer,
       maxWidth,
+      responsiveness,
       centerHtmlOutput,
       clickableLink,
       imagePath,
@@ -143,6 +162,7 @@
       fileType = config.fileType;
       includeResizer = config.includeResizer;
       maxWidth = config.maxWidth;
+      responsiveness = config.responsiveness;
       centerHtmlOutput = config.centerHtmlOutput;
       clickableLink = config.clickableLink;
       imagePath = config.imagePath;
@@ -399,6 +419,18 @@
       <div class="setting">
         <Section>Clickable Link</Section>
         <input type="text" placeholder="Link image?" bind:value={clickableLink} on:change={onChangeConfig} />
+      </div>
+    </div>
+    <div class="row">
+      <div class="setting">
+        <Section>Responsiveness</Section>
+        <SelectMenu
+          bind:menuItems={responsivenessOptions}
+          on:change={(e) => {
+            responsiveness = e.detail.value;
+            onChangeConfig();
+          }}
+        />
       </div>
     </div>
   </div>

--- a/src/lib/generator/html/frame.ts
+++ b/src/lib/generator/html/frame.ts
@@ -39,6 +39,9 @@ export default ({ node, filename, widthRange, altText, config, variables }) => {
 	// 	return pct.toFixed(2) + '%';
 	// };
 
+	// if responsiveness is fixed, set the width to the max width
+	if (config.responsiveness === 'FIXED') inlineStyle += `width: ${width}px;`;
+
 	frameContent.html += `\n\t<!-- Frame: ${filename.split('/').slice(-1)} -->\n`;
 	frameContent.html += `\t<div ${stringify.attrs({
 		id: id,

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,6 +126,7 @@ class StoredConfig {
 				fileType: 'HTML',
 				includeResizer: true,
 				maxWidth: null,
+				responsiveness: 'DYNAMIC',
 				centerHtmlOutput: false,
 				clickableLink: null,
 				imagePath: 'img',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type Extension = "PNG" | "JPG" | "SVG";
 export type FileType = "SVELTE" | "HTML";
-export type ConstraintType = "SCALE" | "WIDTH" | "HEIGHT";
 export type Scale = 1 | 2 | 4;
+export type Responsiveness = "DYNAMIC" | "FIXED";
 
 export interface Config {
   syntax: string;
@@ -9,6 +9,7 @@ export interface Config {
   extension: Extension;
   fileType: FileType;
   includeResizer: boolean;
+  responsiveness: Responsiveness;
   maxWidth: number;
   centerHtmlOutput: boolean;
   clickableLink: string;


### PR DESCRIPTION
Mimics ai2html's responsiveness functionality as a dropdown in the UI
- `DYNAMIC` (default) makes f2h containers fill the page
- `FIXED` keeps f2h containers at the width they were designed at in Figma