### PR TITLE
Add testingMode

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -105,6 +105,7 @@
 
   let syntax: string | undefined = undefined;
   let includeResizer = true;
+  let testingMode = false;
   let centerHtmlOutput = false;
   let applyStyleNames = false;
   let applyHtags = false;
@@ -136,6 +137,7 @@
       extension,
       fileType,
       includeResizer,
+      testingMode,
       maxWidth,
       responsiveness,
       centerHtmlOutput,
@@ -161,6 +163,7 @@
       scale = config.scale;
       fileType = config.fileType;
       includeResizer = config.includeResizer;
+      testingMode = config.testingMode;
       maxWidth = config.maxWidth;
       responsiveness = config.responsiveness;
       centerHtmlOutput = config.centerHtmlOutput;
@@ -413,16 +416,6 @@
     </div>
     <div class="row">
       <div class="setting">
-        <Section>Add Max Container Width (px)</Section>
-        <input type="number" placeholder="1920" bind:value={maxWidth} on:input={onChangeConfig} />
-      </div>
-      <div class="setting">
-        <Section>Clickable Link</Section>
-        <input type="text" placeholder="Link image?" bind:value={clickableLink} on:change={onChangeConfig} />
-      </div>
-    </div>
-    <div class="row">
-      <div class="setting">
         <Section>Responsiveness</Section>
         <SelectMenu
           bind:menuItems={responsivenessOptions}
@@ -431,6 +424,22 @@
             onChangeConfig();
           }}
         />
+      </div>
+      <div class="setting switch-setting">
+        <div class="switch-title">
+          <Section>Testing Mode</Section>
+        </div>
+        <Switch value={testingMode} bind:checked={testingMode} on:change={onChangeConfig} />
+      </div>
+    </div>
+    <div class="row">
+      <div class="setting">
+        <Section>Add Max Container Width (px)</Section>
+        <input type="number" placeholder="1920" bind:value={maxWidth} on:input={onChangeConfig} />
+      </div>
+      <div class="setting">
+        <Section>Clickable Link</Section>
+        <input type="text" placeholder="Link image?" bind:value={clickableLink} on:change={onChangeConfig} />
       </div>
     </div>
   </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,6 +125,7 @@ class StoredConfig {
 				extension: 'PNG',
 				fileType: 'HTML',
 				includeResizer: true,
+				testingMode: false,
 				maxWidth: null,
 				responsiveness: 'DYNAMIC',
 				centerHtmlOutput: false,
@@ -289,7 +290,7 @@ const getAssets = async (
 
 		// Hide all text layers.
 		let modifiedNode = originalNode.clone();
-		modifiedNode = withModificationsForExport(modifiedNode);
+		modifiedNode = withModificationsForExport(modifiedNode, config);
 
 		if (tempFrame.frame) {
 			tempFrame.frame.appendChild(grouplessNode);
@@ -352,11 +353,17 @@ const withModificationsForText = (node: FrameNode): FrameNode => {
 	return node;
 };
 
-const withModificationsForExport = (node: FrameNode): FrameNode => {
-	// hide all text layers
-	const nodesToHide = node.findAll((c) => c.type === 'TEXT');
+const withModificationsForExport = (node: FrameNode, config: Config): FrameNode => {
 
-	nodesToHide.forEach((node) => (node.visible = false));
+	const textNodes = node.findAll((c) => c.type === 'TEXT');
+
+	if (!config.testingMode) {
+		// hide all text layers if testingMode is false
+		textNodes.forEach((node) => (node.visible = false));
+	} else {
+		// fade all text layers if testingMode is true
+		textNodes.forEach((node) => (node.opacity = 0.5));
+	}
 
 	return node;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface Config {
   extension: Extension;
   fileType: FileType;
   includeResizer: boolean;
+  testingMode: boolean;
   responsiveness: Responsiveness;
   maxWidth: number;
   centerHtmlOutput: boolean;


### PR DESCRIPTION
Adds a toggle to turn on testingMode, similar to ai2html. When turned on, text layers on the exported images are not hidden, but instead faded to `opacity: 0.5` for testing purposes.