### PR TITLE
[fix] Unset height when using fluid container width

### DIFF
--- a/src/lib/generator/html/frame.ts
+++ b/src/lib/generator/html/frame.ts
@@ -71,7 +71,7 @@ export default ({ node, filename, widthRange, alt, config, variables }) => {
 		draggable: 'false',
 		decoding: 'async',
 		width: width.toFixed(2),
-		height: height.toFixed(2)
+		height: !config.fluid ? height.toFixed(2) : 'null'
 	})}/>\n\t\t</picture>\n`;
 
 	if (textData) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -507,7 +507,7 @@ figma.ui.onmessage = async (message) => {
 			figma.ui.resize(size.w, size.h);
 
 			config = await Stored.config.get();
-			Stored.config.write(config);
+			// Stored.config.write(config);
 
 			variables = await Stored.variables.get();
 			panels = await Stored.panels.get();


### PR DESCRIPTION
Fixes #86.

Sets image height to `null` when `Fluid container width` is turned on, which prevents images from stretching horizontally but not resizing vertically.

Also prevents the plugin from writing the current config to a text box on init, a setting which prevented running the plugin on multiple pages within a file with different settings for each.