### PR TITLE
Fix: Text styling

### DIFF
--- a/.changeset/cold-bikes-appear.md
+++ b/.changeset/cold-bikes-appear.md
@@ -1,0 +1,5 @@
+---
+'figma2html': patch
+---
+
+Fix text styling #92. Text styles were broken during a prior refactor, causing `font-family` and `font-size` and other critical styles to not be assigned in the resulting files.

--- a/src/lib/generator/convertTextFrames.ts
+++ b/src/lib/generator/convertTextFrames.ts
@@ -62,9 +62,7 @@ export default (textFrames, frameWidth: number, frameHeight: number) => {
 
 		const baseStyle = {
 			tag,
-			style: textSegments?.[0]?.styles?.string
-				.replace('font-weight: 700', 'font-weight: 400')
-				.replace('font-style: italic', 'font-style: normal')
+			style: styleProps.styles(segments[0]).string.replace('font-weight: 700', 'font-weight: 400')
 		};
 
 		segments.forEach((seg, i) => {


### PR DESCRIPTION
Fix text styling #92. Text styles were broken during a prior refactor, causing `font-family` and `font-size` and other critical styles to not be assigned in the resulting files. This updates the reference that was previously broken.