### PR TITLE
[fix] fixed ending tag for custom script

### DIFF
--- a/.changeset/neat-crabs-nail.md
+++ b/.changeset/neat-crabs-nail.md
@@ -1,0 +1,5 @@
+---
+'figma2html': patch
+---
+
+Fix custom `</script>` ending tag

--- a/src/lib/generator/html/wrapper.ts
+++ b/src/lib/generator/html/wrapper.ts
@@ -42,7 +42,7 @@ export default ({ config, assets, variables }) => {
 			if (config.includeResizer) code += `<script>${js.resizer(containerID)}</script>`;
 			if (config.includeGoogleFonts && fontList.length > 0)
 				code += `<script>${js.fonts(fontList)}</script>`;
-			if (config.customScript) code += `<script>${config.customScript}<script>`;
+			if (config.customScript) code += `<script>${config.customScript}</script>`;
 			break;
 		}
 		case 'svelte': {


### PR DESCRIPTION
The end tag for the custom script was `<script>` instead of `</script>`.

This fixes that.
