### PR TITLE
Fix corrupt google font urls

### DIFF
--- a/.changeset/thick-cobras-cheat.md
+++ b/.changeset/thick-cobras-cheat.md
@@ -1,0 +1,5 @@
+---
+'figma2html': patch
+---
+
+Fix Google Fonts family variant detection

--- a/src/lib/generator/js/fonts.ts
+++ b/src/lib/generator/js/fonts.ts
@@ -17,8 +17,24 @@ export default (fontList) => {
 	// group fontList array by family
 	const typefaces = new Map<string, Set<string>>();
 
-	for (const { family, style } of [...fontList]) {
+	for (let { family, style } of [...fontList]) {
+		// detect if there's a variant such as Condensed.
+		// Figma rolls Condensed, which is technically its own typeface, into the Roboto family here.
+		// it always shows up as the first word in the style string
+		// EX: Condensed ExtraBold Italic
+		const variant =
+			(style.includes('Italic') ? style.split(' ').length === 3 : style.split(' ').length === 2) &&
+			style.split(' ')[0];
+
+		// if there's a variant, remove it from the style and append to the family name
+		if (variant) {
+			family = `${family} ${variant}`;
+			style = style.replace(`${variant} `, '');
+		}
+
+		// google reads italic as 1, normal as 0
 		const googleStyle = style.includes('Italic') ? '1,' : '0,';
+
 		const weight =
 			style === 'Italic' ? weightLookup['Regular'] : weightLookup[style.replace(' Italic', '')];
 		const styleWeight = `${googleStyle}${weight}`;


### PR DESCRIPTION
Closes #109. The Google font detection was faulty and frequently created output with 'undefined' in the url. We weren't properly detecting variant fonts like "Roboto Condensed" vs. "Roboto".

For the nerds, Figma rolls up "Roboto Condensed" into "Roboto" so the style string would look like "Condensed ExtraBold Italic" and the fontName would be "Roboto". This is not ideal for us. I've added a simple detection in the script to uncover if theres a variant and apply it back to the font name.

```js
// detect if there's a variant such as Condensed.
// Figma rolls Condensed, which is technically its own typeface, into the Roboto family here.
// it always shows up as the first word in the style string
// EX: Condensed ExtraBold Italic
const variant =
	(style.includes('Italic') ? style.split(' ').length === 3 : style.split(' ').length === 2) &&
	style.split(' ')[0];

// if there's a variant, remove it from the style and append to the family name
if (variant) {
	family = `${family} ${variant}`;
	style = style.replace(`${variant} `, '');
}
```