### PR TITLE
[fix] text-transform CSS from Figma TextCase

### DIFF
--- a/src/lib/generator/styleProps.ts
+++ b/src/lib/generator/styleProps.ts
@@ -1,3 +1,5 @@
+import textCaseFigmaToCss from 'lib/utils/textCaseFigmaToCss';
+
 export const fontList = [];
 
 // TODO: shouldn't this use our stringify function?
@@ -24,7 +26,7 @@ export const styles = (segment: StyledTextSegment) => {
 		'font-weight': segment.fontWeight,
 		'font-size': segment.fontSize + 'px',
 		'text-decoration': segment.textDecoration.toLowerCase(),
-		'text-transform': segment.textCase === 'ORIGINAL' ? 'none' : segment.textCase.toLowerCase(),
+		'text-transform': textCaseFigmaToCss(segment.textCase),
 		'line-height':
 			segment.lineHeight.unit === 'AUTO'
 				? 'normal'

--- a/src/lib/utils/textCaseFigmaToCss.ts
+++ b/src/lib/utils/textCaseFigmaToCss.ts
@@ -1,0 +1,18 @@
+/**
+ * Converts [Figma's TextCase][figma] values to [CSS text-transform][css]
+ * values.
+ *
+ * [figma]: https://www.figma.com/plugin-docs/api/TextCase/
+ * [css]: https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform
+ */
+export default (textCase: TextCase) => {
+	const textCaseMapping = {
+		ORIGINAL: 'none',
+		UPPER: 'uppercase',
+		LOWER: 'lowercase',
+		TITLE: 'capitalize',
+		SMALL_CAPS: 'uppercase',
+		SMALL_CAPS_FORCED: 'uppercase'
+	} as Record<TextCase, string>;
+	return textCaseMapping[textCase];
+};


### PR DESCRIPTION
The `styleProps` generator was converting [Figma's `TextCase` values](https://www.figma.com/plugin-docs/api/TextCase/) to CSS by lowercasing values other than `ORIGINAL`, resulting in invalid CSS values for `text-transform` like `upper` (rather than `uppercase`). This fixes that conversion by adding a utility function to properly map `TextCase` values to CSS values.

[Find a simple reproduction here](https://www.figma.com/design/hYCtzyVCxlXWDkQJ2AtfBr/figma2html-text-case-repro?node-id=0-1&t=PGQ1Yx1e69q3bxR7-1). This is a proposed fix for https://github.com/the-dataface/figma2html/issues/113
